### PR TITLE
Item spawn

### DIFF
--- a/game/entities/enemies/enemy/enemy.gd
+++ b/game/entities/enemies/enemy/enemy.gd
@@ -9,6 +9,8 @@ extends CharacterBody2D
 @onready var aggression_area: Area2D = $"Aggression Area"
 @export var item_manager: ItemManager
 
+signal died(enemy:Enemy)
+
 func _ready():
 	anim.play("idle")
 	$HealthComponent.max_health = 50
@@ -31,7 +33,7 @@ func attack(body: Node2D) -> void:
 func _on_unit_died() -> void:
 	print("Enemy Died!")
 	GlobalState.shards += 10
-	item_manager.spawn_item(position)
+	died.emit(self)
 	queue_free()
 	
 func take_damage(damage):

--- a/game/entities/enemies/enemy/enemy.gd
+++ b/game/entities/enemies/enemy/enemy.gd
@@ -7,7 +7,6 @@ extends CharacterBody2D
 @export var speed: float = 80.0
 @onready var anim: AnimatedSprite2D = $EnemyTexture
 @onready var aggression_area: Area2D = $"Aggression Area"
-@export var item_manager: ItemManager
 
 signal died(enemy:Enemy)
 

--- a/game/entities/player/player.tscn
+++ b/game/entities/player/player.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Script" uid="uid://blionrlb4f6lq" path="res://common/state_machine/state_machine.gd" id="4_cjfdk"]
 [ext_resource type="Script" uid="uid://dqruoijd822sn" path="res://game/entities/player/states/idle.gd" id="5_oic1i"]
 [ext_resource type="Script" uid="uid://cmmsmv02vlrhy" path="res://game/entities/player/states/move.gd" id="6_v0nmi"]
-[ext_resource type="Script" uid="uid://b5a7yon16mysx" path="res://game/component/stat_components.gd" id="7_5wwt0"]
+[ext_resource type="Script" path="res://game/component/stat_components.gd" id="7_5wwt0"]
 [ext_resource type="Script" uid="uid://cmgcqf3lyxahe" path="res://game/component/health_component.gd" id="7_dhej3"]
 [ext_resource type="Script" uid="uid://dxai1d6m77wum" path="res://game/ui/health_bar/health_bar.gd" id="8_kn1iv"]
 
@@ -439,7 +439,6 @@ unique_name_in_owner = true
 script = ExtResource("7_5wwt0")
 defense = 10
 movement_speed = 200
-metadata/_custom_type_script = "uid://b5a7yon16mysx"
 
 [node name="HealthComponent" type="Node" parent="."]
 script = ExtResource("7_dhej3")

--- a/game/scenes/dungeon/dungeon.gd
+++ b/game/scenes/dungeon/dungeon.gd
@@ -18,6 +18,7 @@ extends Node2D
 @onready var player: CharacterBody2D = $Player
 @onready var dungeon_manager: DungeonManager = $DungeonManager
 @onready var enemy_manager: EnemyManager = $EnemyManager
+@onready var item_manager: ItemManager = $ItemManager
 
 # --- PRIVATE VARIABLES ---
 var _player_spawn_pos: Vector2i
@@ -61,7 +62,6 @@ func pause() -> void:
 	$"/root/SceneManager".change_scene("res://game/ui/pause_screen/pause_screen.tscn")
 	pass # Replace with function body.
 
-
 func _on_dungeon_timeout() -> void:
 	# Set timeout flag and calculate time spent (20 minutes = 1200 seconds)
 	GlobalState.dungeon_timed_out = true
@@ -94,3 +94,6 @@ func format_time(seconds: float) -> String:
 	var minutes = int(seconds) / 60
 	var secs = int(seconds) % 60
 	return "%02d:%02d" % [minutes, secs]
+
+func enemy_died(position: Vector2i) -> void:
+	item_manager.spawn_item(position)

--- a/game/scenes/dungeon/dungeon.tscn
+++ b/game/scenes/dungeon/dungeon.tscn
@@ -103,4 +103,5 @@ z_index = 5
 [node name="GameTimer" type="Timer" parent="."]
 
 [connection signal="pressed" from="Player/UI/Button" to="." method="pause"]
+[connection signal="enemy_died" from="EnemyManager" to="." method="enemy_died"]
 [connection signal="body_entered" from="Ladder" to="." method="leave_dungeon_floor"]

--- a/game/scenes/dungeon/managers/enemy_manager.gd
+++ b/game/scenes/dungeon/managers/enemy_manager.gd
@@ -15,6 +15,7 @@ class_name EnemyManager
 ## The base number of enemies to spawn on floor 1.
 @export var base_enemy_count: int = 3
 
+signal enemy_died(position:Vector2i)
 
 func _ready():
 	randomize()
@@ -39,5 +40,8 @@ func spawn_enemies():
 
 			enemy.global_position = world_pos
 			enemy.item_manager = item_manager
+			enemy.connect("died", _on_enemy_died)
 			self.add_child(enemy)
-	
+
+func _on_enemy_died(enemy: Enemy) -> void:
+	enemy_died.emit(enemy.position)

--- a/game/scenes/dungeon/managers/enemy_manager.gd
+++ b/game/scenes/dungeon/managers/enemy_manager.gd
@@ -39,7 +39,6 @@ func spawn_enemies():
 			var world_pos = dungeon_manager.floor_layer.to_global(local_pos) + tile_size * 0.5
 
 			enemy.global_position = world_pos
-			enemy.item_manager = item_manager
 			enemy.connect("died", _on_enemy_died)
 			self.add_child(enemy)
 


### PR DESCRIPTION
Removes the ItemManager from the enemy. Instead the enemy emits an died signal that the enemies manager can respond to. In this case it also emits an enemy died signal which the dungeon responds to by telling the ItemManager what to do. 