### PR TITLE
Added an Inventory Pop-up (on "I") with empty Loadout and Loot slots

### DIFF
--- a/game/entities/player/player.tscn
+++ b/game/entities/player/player.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Script" uid="uid://blionrlb4f6lq" path="res://common/state_machine/state_machine.gd" id="4_cjfdk"]
 [ext_resource type="Script" uid="uid://dqruoijd822sn" path="res://game/entities/player/states/idle.gd" id="5_oic1i"]
 [ext_resource type="Script" uid="uid://cmmsmv02vlrhy" path="res://game/entities/player/states/move.gd" id="6_v0nmi"]
-[ext_resource type="Script" uid="uid://b5a7yon16mysx" path="res://game/component/stat_component.gd" id="7_5wwt0"]
+[ext_resource type="Script" path="res://game/component/stat_component.gd" id="7_5wwt0"]
 [ext_resource type="Script" uid="uid://dxai1d6m77wum" path="res://game/ui/health_bar/health_bar.gd" id="8_kn1iv"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_nybob"]
@@ -442,7 +442,6 @@ movement_speed = 200
 unique_name_in_owner = true
 script = ExtResource("7_5wwt0")
 max_health = 100
-metadata/_custom_type_script = "uid://b5a7yon16mysx"
 
 [node name="ProgressBar" type="ProgressBar" parent="."]
 offset_left = -33.0

--- a/game/scenes/dungeon/dungeon.tscn
+++ b/game/scenes/dungeon/dungeon.tscn
@@ -51,15 +51,15 @@ offset_bottom = -133.0
 [node name="Button" type="Button" parent="Player/UI"]
 z_index = 50
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -27.5
-offset_top = -15.5
-offset_right = 27.5
-offset_bottom = 15.5
+anchors_preset = -1
+anchor_left = -3.387
+anchor_top = -1.712
+anchor_right = -3.387
+anchor_bottom = -1.712
+offset_left = -27.52
+offset_top = -15.52
+offset_right = 27.48
+offset_bottom = 15.48
 grow_horizontal = 2
 grow_vertical = 2
 text = "Pause"
@@ -67,10 +67,15 @@ text = "Pause"
 [node name="TimerDisplay" parent="Player/UI" node_paths=PackedStringArray("dungeon_scene") instance=ExtResource("11_timer")]
 z_index = 50
 layout_mode = 1
-offset_left = 453.0
-offset_top = 3.0
-offset_right = 573.0
-offset_bottom = 43.0
+anchors_preset = -1
+anchor_left = 17.775
+anchor_top = -1.6
+anchor_right = 17.775
+anchor_bottom = -1.6
+offset_left = -60.0001
+offset_top = -20.0
+offset_right = 59.9999
+offset_bottom = 20.0
 dungeon_scene = NodePath("../../..")
 
 [node name="Potion" parent="Player" instance=ExtResource("3_8kubn")]

--- a/game/scenes/town/town.gd
+++ b/game/scenes/town/town.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Node
 
 @onready var shards_label: Label = $"Shards Label"
 

--- a/game/scenes/town/town.tscn
+++ b/game/scenes/town/town.tscn
@@ -2,29 +2,44 @@
 
 [ext_resource type="Script" uid="uid://cmwnn5rbtl1mv" path="res://game/scenes/town/town.gd" id="1_hywto"]
 
-[node name="Town" type="Node2D"]
+[node name="Town" type="Node"]
 script = ExtResource("1_hywto")
 
 [node name="Enter Dungeon" type="Button" parent="."]
-offset_left = 269.0
-offset_top = 166.0
-offset_right = 393.0
-offset_bottom = 197.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -62.0
+offset_top = -15.5
+offset_right = 62.0
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
 text = "Enter Dungeon"
 
 [node name="Label" type="Label" parent="."]
-offset_left = 283.0
-offset_top = 33.0
-offset_right = 375.0
-offset_bottom = 82.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -46.0
+offset_top = 150.0
+offset_right = 46.0
+offset_bottom = 199.0
+grow_horizontal = 2
 text = "Town Scene
 "
 
 [node name="Shards Label" type="Label" parent="."]
-offset_left = 254.0
-offset_top = 71.0
-offset_right = 397.0
-offset_bottom = 94.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -71.5
+offset_top = 189.0
+offset_right = 71.5
+offset_bottom = 212.0
+grow_horizontal = 2
 text = "You Have 0 Shards"
 
 [connection signal="pressed" from="Enter Dungeon" to="." method="enter_dungeon"]

--- a/game/ui/inventory/inventory.gd
+++ b/game/ui/inventory/inventory.gd
@@ -1,0 +1,20 @@
+extends Node
+
+@onready var inventory_ui: CanvasLayer = preload("res://game/ui/inventory/inventory.tscn").instantiate() as CanvasLayer
+
+func _ready() -> void:
+	print("InventoryManager ready")
+	add_child(inventory_ui)
+	inventory_ui.visible = false
+	set_process_unhandled_input(true)
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("inventory"):
+		_toggle_inventory()
+
+func _toggle_inventory() -> void:
+	inventory_ui.visible = not inventory_ui.visible
+	if inventory_ui.visible:
+		print("Inventory opened")
+	else:
+		print("Inventory closed")

--- a/game/ui/inventory/inventory.gd.uid
+++ b/game/ui/inventory/inventory.gd.uid
@@ -1,0 +1,1 @@
+uid://dopkoe0rxen6y

--- a/game/ui/inventory/inventory.tscn
+++ b/game/ui/inventory/inventory.tscn
@@ -1,0 +1,169 @@
+[gd_scene load_steps=2 format=3 uid="uid://0h1jqahk6bbt"]
+
+[ext_resource type="Texture2D" uid="uid://byebjcter8a1r" path="res://assets/kenney_tiny-dungeon/Tiles/tile_0064.png" id="1_1ghxt"]
+
+[node name="Inventory" type="CanvasLayer"]
+
+[node name="InventoryPanel" type="Panel" parent="."]
+custom_minimum_size = Vector2(200, 450)
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -200.0
+offset_bottom = 200.0
+grow_horizontal = 0
+grow_vertical = 2
+
+[node name="InventoryContainer" type="VBoxContainer" parent="InventoryPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="LoadoutContainer" type="CenterContainer" parent="InventoryPanel/InventoryContainer"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="InventoryPanel/InventoryContainer/LoadoutContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="TopRow" type="CenterContainer" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="HatSlot" type="ColorRect" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer/TopRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="MiddleRow" type="HBoxContainer" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="StaffSlot" type="ColorRect" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.125911, 0.125911, 0.125911, 1)
+
+[node name="RobeSlot" type="ColorRect" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="ShieldSlot" type="ColorRect" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="BottomRow" type="CenterContainer" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="BootsSlot" type="ColorRect" parent="InventoryPanel/InventoryContainer/LoadoutContainer/VBoxContainer/BottomRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="SeparatorContainer" type="HBoxContainer" parent="InventoryPanel/InventoryContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="SeparatorLine" type="Line2D" parent="InventoryPanel/InventoryContainer/SeparatorContainer"]
+points = PackedVector2Array(0, 0, 200, 0)
+width = 3.0
+default_color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="LootContainer" type="CenterContainer" parent="InventoryPanel/InventoryContainer"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="InventoryPanel/InventoryContainer/LootContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="TopRow" type="HBoxContainer" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="LootSlot1" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/TopRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.125911, 0.125911, 0.125911, 1)
+
+[node name="LootItem1" type="TextureRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/TopRow/LootSlot1"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("1_1ghxt")
+
+[node name="LootSlot2" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/TopRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="LootSlot3" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/TopRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="MiddleRow" type="HBoxContainer" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="LootSlot4" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.125911, 0.125911, 0.125911, 1)
+
+[node name="LootSlot5" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="LootSlot6" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/MiddleRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="BottomRow" type="HBoxContainer" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="LootSlot7" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/BottomRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.125911, 0.125911, 0.125911, 1)
+
+[node name="LootSlot8" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/BottomRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)
+
+[node name="LootSlot9" type="ColorRect" parent="InventoryPanel/InventoryContainer/LootContainer/VBoxContainer/BottomRow"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.12549, 0.12549, 0.12549, 1)

--- a/game/ui/main_menu/main_menu.tscn
+++ b/game/ui/main_menu/main_menu.tscn
@@ -6,17 +6,28 @@
 script = ExtResource("1_gof3u")
 
 [node name="Button" type="Button" parent="."]
-offset_left = 268.0
-offset_top = 148.0
-offset_right = 309.0
-offset_bottom = 179.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.5
+offset_top = -15.5
+offset_right = 20.5
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
 text = "Play"
 
 [node name="Label" type="Label" parent="."]
-offset_left = 265.0
-offset_top = 83.0
-offset_right = 305.0
-offset_bottom = 106.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -71.5
+offset_top = 150.0
+offset_right = 71.5
+offset_bottom = 173.0
+grow_horizontal = 2
 text = "Slay The Dungeon!"
 
 [connection signal="pressed" from="Button" to="." method="play"]

--- a/game/ui/pause_screen/pause_screen.tscn
+++ b/game/ui/pause_screen/pause_screen.tscn
@@ -6,25 +6,43 @@
 script = ExtResource("1_f2q6y")
 
 [node name="ResumeButton" type="Button" parent="."]
-offset_left = 273.0
-offset_top = 118.0
-offset_right = 343.0
-offset_bottom = 149.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -35.0
+offset_top = -15.5
+offset_right = 35.0
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
 text = "Resume
 "
 
 [node name="PausedLabel" type="Label" parent="."]
-offset_left = 276.0
-offset_top = 65.0
-offset_right = 333.0
-offset_bottom = 88.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -28.5
+offset_top = 150.0
+offset_right = 28.5
+offset_bottom = 173.0
+grow_horizontal = 2
 text = "Paused"
 
 [node name="MainMenuButton" type="Button" parent="."]
-offset_left = 263.0
-offset_top = 178.0
-offset_right = 359.0
-offset_bottom = 209.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -48.0
+offset_top = 30.0
+offset_right = 48.0
+offset_bottom = 61.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "Main Menu"
 
 [connection signal="pressed" from="ResumeButton" to="." method="resume"]

--- a/game/ui/settings_screen/settings_screen.tscn
+++ b/game/ui/settings_screen/settings_screen.tscn
@@ -6,18 +6,29 @@
 script = ExtResource("1_mwbxr")
 
 [node name="Label" type="Label" parent="."]
-offset_left = 214.0
-offset_top = 34.0
-offset_right = 254.0
-offset_bottom = 57.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -59.0
+offset_top = 150.0
+offset_right = 59.0
+offset_bottom = 173.0
+grow_horizontal = 2
 rotation = -0.00516901
 text = "Settings screen"
 
 [node name="Button" type="Button" parent="."]
-offset_left = 118.0
-offset_top = 40.0
-offset_right = 163.0
-offset_bottom = 71.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -22.5
+offset_top = -15.5
+offset_right = 22.5
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
 text = "Back"
 
 [connection signal="pressed" from="Button" to="." method="exit_settings"]

--- a/game/ui/summary_screen/summary_screen.tscn
+++ b/game/ui/summary_screen/summary_screen.tscn
@@ -2,35 +2,57 @@
 
 [ext_resource type="Script" uid="uid://djip16umi6qh0" path="res://game/ui/summary_screen/summary_screen.gd" id="1_vla81"]
 
-[node name="SummaryScreen" type="Node2D"]
+[node name="SummaryScreen" type="Node"]
 script = ExtResource("1_vla81")
 
 [node name="SummaryScreen" type="Label" parent="."]
-offset_left = 244.0
-offset_top = 40.0
-offset_right = 375.0
-offset_bottom = 63.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -65.5
+offset_top = 150.0
+offset_right = 65.5
+offset_bottom = 173.0
+grow_horizontal = 2
 text = "Summary Screen"
 
 [node name="ShardsLabel" type="Label" parent="."]
-offset_left = 246.0
-offset_top = 82.0
-offset_right = 377.0
-offset_bottom = 105.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -71.5
+offset_top = 185.0
+offset_right = 71.5
+offset_bottom = 208.0
+grow_horizontal = 2
 text = "You Have 0 Shards"
 
 [node name="Return To Town" type="Button" parent="."]
-offset_left = 247.0
-offset_top = 129.0
-offset_right = 375.0
-offset_bottom = 160.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -15.5
+offset_right = 64.0
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
 text = "Return to Town"
 
 [node name="Main Menu" type="Button" parent="."]
-offset_left = 259.0
-offset_top = 171.0
-offset_right = 355.0
-offset_bottom = 202.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -48.0
+offset_top = 30.0
+offset_right = 48.0
+offset_bottom = 61.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "Main Menu"
 
 [connection signal="pressed" from="Return To Town" to="." method="enter_town"]

--- a/game/ui/timer_display/timer_display.tscn
+++ b/game/ui/timer_display/timer_display.tscn
@@ -4,14 +4,9 @@
 
 [node name="TimerDisplay" type="Control"]
 layout_mode = 3
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -696.0
-offset_top = -21.0
-offset_right = -576.0
-offset_bottom = 19.0
-grow_horizontal = 0
+anchors_preset = 0
+offset_right = 120.0
+offset_bottom = 40.0
 script = ExtResource("1_0k8vx")
 
 [node name="TimerLabel" type="Label" parent="."]

--- a/game/ui/victory_screen/victory_scene.tscn
+++ b/game/ui/victory_screen/victory_scene.tscn
@@ -5,27 +5,47 @@
 [node name="VictoryScene" type="Node"]
 script = ExtResource("1_m2cr5")
 
-[node name="ReturnToTownButton" type="Button" parent="."]
-offset_left = 273.0
-offset_top = 118.0
-offset_right = 343.0
-offset_bottom = 149.0
-text = "Return to Town"
-
 [node name="VictoryLabel" type="Label" parent="."]
-offset_left = 199.0
-offset_top = 30.0
-offset_right = 571.0
-offset_bottom = 105.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -186.0
+offset_top = 150.0
+offset_right = 186.0
+offset_bottom = 225.0
+grow_horizontal = 2
 text = "Congratulations!
 You've Slayed the
 Dungeon!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ReturnToTownButton" type="Button" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -15.5
+offset_right = 64.0
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
+text = "Return to Town"
 
 [node name="MainMenuButton" type="Button" parent="."]
-offset_left = 263.0
-offset_top = 178.0
-offset_right = 359.0
-offset_bottom = 209.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -48.0
+offset_top = 40.0
+offset_right = 48.0
+offset_bottom = 71.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "Main Menu"
 
 [connection signal="pressed" from="ReturnToTownButton" to="." method="return_to_town"]

--- a/project.godot
+++ b/project.godot
@@ -19,13 +19,14 @@ config/icon="res://icon.svg"
 
 SceneManager="*res://common/autoload/scene_manager.gd"
 GlobalState="*res://util/global_state.gd"
+Inventory="*res://game/ui/inventory/inventory.gd"
 
 [display]
 
-window/size/viewport_width=1920
-window/size/viewport_height=1080
+window/size/viewport_width=960
+window/size/viewport_height=540
 window/stretch/mode="canvas_items"
-window/stretch/scale=3.0
+window/stretch/scale=1
 window/stretch/scale_mode="integer"
 
 [file_customization]
@@ -88,6 +89,11 @@ move_up={
 move_down={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+inventory={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/util/global_state.gd
+++ b/util/global_state.gd
@@ -1,5 +1,6 @@
-extends Node
+# util/global_state.gd
 
+extends Node
 
 @export var shards: int = 0
 @export var dungeon_timed_out: bool = false
@@ -9,11 +10,11 @@ extends Node
 enum ItemTypes {HAT, ROBE, SHIELD, BOOTS}
 
 signal item_equipped
-signal item_picked_up
+signal item_picked_up(item)
 
 var inventory: Array = []
 var equipment: Dictionary = {}
-var max_inventory:int = 20
+var max_inventory:int = 9
 
 func pickup_item(item: ItemData):
 	print("pickup")
@@ -21,11 +22,11 @@ func pickup_item(item: ItemData):
 		if !equipment.has(item.type):
 			print("Automatically Equipping: ", item)
 			equipment[item.type] = item
-			item_equipped.emit()
+			item_equipped.emit(item)
 		else:
 			print("Item Picked Up: ", item)
 			inventory.append(item)
-		item_picked_up.emit()
+		item_picked_up.emit(item)
 		
 		print("Inventory: ", inventory)
 


### PR DESCRIPTION
- Inventory scene pops up with transparent background and two containers (loadout on top, loot on bottom)
- Placed a placeholder image in the first loot slot (not sure yet how to handle the interaction with the loot system)
- Opens and closes with "I" key (global event listener runs inventory.gd)
- Loot container is a Grid so it can easily be converted to a dynamic size if needed
- TextureRect's are likely needed to populate visuals (the empty slots are just colored squared in the grid
- Updated the world size and scale so scale is 1 (it was starting to get really hard to size any UI elements)
- Cleaned up anchors and positioning for menu scenes so everything is centered and clean (how it looks in the editor is also now how it looks on screen). 